### PR TITLE
Fix symbols and currencies endpoints

### DIFF
--- a/lib/servers/rest2.js
+++ b/lib/servers/rest2.js
@@ -11,8 +11,8 @@ const METHODS = {
   '/v2/tickers/hist': 'tickers_hist',
   '/v2/stats1/:key/:context': 'stats.{key}.{context}',
   '/v2/candles/:key/:section': 'candles.{key}.{section}',
-  '/v2/conf/pub:list:pair:exchange': 'symbols',
-  '/v2/conf/pub:map:currency:label': 'currencies',
+  '/v2/conf/pub([:])list([:])pair([:])exchange\*': 'symbols',
+  '/v2/conf/pub([:])list([:])currency\*': 'currencies',
   '/v2/trades/:symbol/hist': 'public_trades.{symbol}.{start}.{end}.{limit}.{sort}',
 
   '/v2/auth/r/alerts': 'alerts.{type}',

--- a/lib/servers/rest2.js
+++ b/lib/servers/rest2.js
@@ -12,6 +12,7 @@ const METHODS = {
   '/v2/stats1/:key/:context': 'stats.{key}.{context}',
   '/v2/candles/:key/:section': 'candles.{key}.{section}',
   '/v2/conf/pub([:])list([:])pair([:])exchange\*': 'symbols',
+  '/v2/conf/pub([:])list([:])pair([:])futures\*': 'futures',
   '/v2/conf/pub([:])list([:])currency\*': 'currencies',
   '/v2/trades/:symbol/hist': 'public_trades.{symbol}.{start}.{end}.{limit}.{sort}',
 


### PR DESCRIPTION
This PR fixes symbols and currencies endpoints. This related to specific of the express router:
  - if we need to use the `:` character in a path string, enclose it escaped within `([:])` http://expressjs.com/en/guide/routing.html