### PR TITLE
Add account summary endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.3
+- feature: add account summary endpoint
+
 # 1.0.2
 - feature: add logins endpoint
 

--- a/data/rest2.json
+++ b/data/rest2.json
@@ -31,5 +31,6 @@
   "movements": [],
   "user_info": [],
   "public_trades": [],
-  "derivs_pos_col_set": []
+  "derivs_pos_col_set": [],
+  "account_summary": []
 }

--- a/lib/servers/rest2.js
+++ b/lib/servers/rest2.js
@@ -53,7 +53,8 @@ const METHODS = {
   '/v2/auth/r/ledgers/hist': 'ledgers',
   '/v2/auth/r/movements/:symbol/hist': 'movements.{symbol}.{start}.{end}.{limit}',
   '/v2/auth/r/movements/hist': 'movements',
-  '/v2/auth/r/info/user': 'user_info'
+  '/v2/auth/r/info/user': 'user_info',
+  '/v2/auth/r/int/summary': 'account_summary'
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-mock-srv",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Bitfinex API server mock library",
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
### Description:
Add a new endpoint to mock, account summary, that doesn't receive params

### New features:
- Account summary endpoint

### PR status:
- Version bumped
- Change-log updated
- Tests added or updated
