### PR TITLE
Feature - rest v1 to v2 migration endpoints

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+# 1.1.1
+- feature: add order submit endpoint
+- feature: add auth permissions endpoint
+- feature: add pair info endpoint
+- feature: add currency tx fee endpoint
+- fix: fix account summary endpoint
+
 # 1.1.0
 - feature: dynamic responses
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.1.0
+- feature: dynamic responses
+
 # 1.0.16
 - feature: add generate token endpoint
 

--- a/data/rest2.json
+++ b/data/rest2.json
@@ -39,5 +39,9 @@
   "get_settings": [],
   "generate_token": [],
   "map_symbols": [],
-  "inactive_currencies": []
+  "inactive_currencies": [],
+  "auth_permissions": [],
+  "map_ccy_fees": [],
+  "info_pairs": [],
+  "order_submit": []
 }

--- a/lib/rest2/index.js
+++ b/lib/rest2/index.js
@@ -4,6 +4,7 @@ const express = require('express')
 const Bluebird = require('bluebird')
 const bodyParser = require('body-parser')
 const _keys = require('lodash/keys')
+const _isFunction = require('lodash/isFunction')
 const _isUndefined = require('lodash/isUndefined')
 const debug = require('debug')('bfx:api-mock-srv:rest2')
 
@@ -109,7 +110,8 @@ class MockRESTv2Server extends MockServer {
           if (!response) continue // could be null
 
           try {
-            return res.json(JSON.parse(response))
+            const data = _isFunction(response) ? response() : JSON.parse(response)
+            return res.json(data)
           } catch (err) {
             return res.status(500).json({
               error: 'bad response json'

--- a/lib/rest2/methods.js
+++ b/lib/rest2/methods.js
@@ -65,7 +65,7 @@ const RESTV2_MOCK_METHODS = {
   '/v2/auth/r/movements/:symbol/hist': 'movements.{symbol}.{start}.{end}.{limit}',
   '/v2/auth/r/movements/hist': 'movements',
   '/v2/auth/r/info/user': 'user_info',
-  '/v2/auth/r/int/summary': 'account_summary',
+  '/v2/auth/r/summary': 'account_summary',
   '/v2/auth/w/pulse/add': 'add_pulse.{title}.{content}',
   '/v2/auth/w/pulse/del': 'delete_pulse.{pid}',
   '/v2/auth/r/pulse/hist': 'pulse_hist.{isPublic}',

--- a/lib/rest2/methods.js
+++ b/lib/rest2/methods.js
@@ -14,6 +14,7 @@ const RESTV2_MOCK_METHODS = {
   '/v2/stats1/:key/:context': 'stats.{key}.{context}',
   '/v2/status/:type': 'status_messages.{type}.{keys}',
   '/v2/candles/:key/:section': 'candles.{key}.{section}',
+  '/v2/conf/pub([:])map([:])currency([:])tx([:])fee\*': 'map_ccy_fees', // eslint-disable-line
   '/v2/conf/pub([:])map([:])pair([:])sym\*': 'map_symbols', // eslint-disable-line
   '/v2/conf/pub([:])list([:])currency([:])inactive\*': 'inactive_currencies', // eslint-disable-line
   '/v2/conf/pub([:])list([:])pair([:])exchange([:])inactive\*': 'inactive_symbols', // eslint-disable-line

--- a/lib/rest2/methods.js
+++ b/lib/rest2/methods.js
@@ -74,6 +74,7 @@ const RESTV2_MOCK_METHODS = {
   '/v2/auth/r/pulse/hist': 'pulse_hist.{isPublic}',
   '/v2/auth/w/deposit/invoice': 'generate_invoice.{currency}.{wallet}.{amount}',
   '/v2/auth/w/funding/keep': 'keep_funding.{type}.{id}',
+  '/v2/auth/w/order/submit': 'order_submit',
   '/v2/auth/w/order/cancel/multi': 'cancel_order_multi.{id}',
   '/v2/auth/w/order/multi': 'order_multi_op.{ops}',
   '/v2/auth/w/settings/set': 'set_settings.{settings}',

--- a/lib/rest2/methods.js
+++ b/lib/rest2/methods.js
@@ -68,6 +68,7 @@ const RESTV2_MOCK_METHODS = {
   '/v2/auth/r/movements/hist': 'movements',
   '/v2/auth/r/info/user': 'user_info',
   '/v2/auth/r/summary': 'account_summary',
+  '/v2/auth/r/permissions': 'auth_permissions',
   '/v2/auth/w/pulse/add': 'add_pulse.{title}.{content}',
   '/v2/auth/w/pulse/del': 'delete_pulse.{pid}',
   '/v2/auth/r/pulse/hist': 'pulse_hist.{isPublic}',

--- a/lib/rest2/methods.js
+++ b/lib/rest2/methods.js
@@ -22,6 +22,7 @@ const RESTV2_MOCK_METHODS = {
   '/v2/conf/pub([:])list([:])pair([:])futures\*': 'futures', // eslint-disable-line
   '/v2/conf/pub([:])list([:])pair([:])margin\*': 'margins', // eslint-disable-line
   '/v2/conf/pub([:])list([:])currency\*': 'currencies', // eslint-disable-line
+  '/v2/conf/pub([:])info([:])pair\*': 'info_pairs', // eslint-disable-line
   '/v2/trades/:symbol/hist': 'public_trades.{symbol}.{start}.{end}.{limit}.{sort}',
   '/v2/liquidations/hist': 'liquidations.{start}.{end}.{limit}.{sort}',
   '/v2/pulse/profile/:nickname': 'public_pulse_profile.{nickname}',

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const _isFunction = require('lodash/isFunction')
 const fs = require('fs')
 const express = require('express')
 const bodyParser = require('body-parser')
@@ -149,7 +150,8 @@ class MockServer extends EventEmitter {
    * @param {Array|object} data - data
    */
   setResponse (key, data) {
-    this._responses.set(key, JSON.stringify(data))
+    const res = _isFunction(data) ? data : JSON.stringify(data)
+    this._responses.set(key, res)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-mock-srv",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "description": "Bitfinex API server mock library",
   "engines": {
     "node": ">=7.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-mock-srv",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Bitfinex API server mock library",
   "engines": {
     "node": ">=7.6.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "Ezequiel Wernicke <ezequiel.wernicke@bitfinex.com> (https://www.bitfinex.com)",
     "Cris Mihalache <cris.m@bitfinex.com> (https://www.bitfinex.com)",
     "Paolo Ardoino <paolo@bitfinex.com> (https://www.bitfinex.com)",
-    "Vladimir Voronkov <VSVoronkov@gmail.com>"
+    "Vladimir Voronkov <VSVoronkov@gmail.com>",
+    "Vigan Abdurrahmani <vigan.abdurrahmani@bitfinex.com> (https://www.bitfinex.com)"
   ],
   "author": "Bitfinex",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description:
This PR adds the endpoints needed for https://github.com/bitfinexcom/bfx-api-node-rest/pull/78

**Note!** before merging this PR merge previous PR https://github.com/bitfinexcom/bfx-api-mock-srv/pull/44 since it includes also changes in that PR

### Breaking changes:
- account_summary now points to /v2/auth/r/summary instead of /v2/auth/r/int/summary

### New features:
- added order submit endpoint
- added auth permissions endpoint
- added pair info endpoint
- added currency tx fee endpoint

### Fixes:
- fixed account summary endpoint

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
